### PR TITLE
Add Time Stepper Panel for quicker Hour and Minute selection

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -1776,10 +1776,10 @@
             this.selectedTimes.length === 2 &&
             ((timeIndex === 0 &&
               this.selectedTimes[1] &&
-              newTime.isAfter(this.selectedTimes[1])) ||
+              newTime.isAfter(this.selectedTimes[1] as PersianDate)) ||
               (timeIndex === 1 &&
                 this.selectedTimes[0] &&
-                newTime.isBefore(this.selectedTimes[0])))
+                newTime.isBefore(this.selectedTimes[0] as PersianDate)))
           ) {
             // invalid range
           } else {

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -7,6 +7,7 @@
       { 'pdp-modal': modal },
       { 'pdp-dual': dualInput },
       lang.dir.input,
+      { 'pdp--time-panel-open': showTimePanel },
     ]"
   >
     <slot name="before">
@@ -161,6 +162,41 @@
             </div>
           </div>
           <div ref="pdpMain" class="pdp-main">
+            <div v-show="showTimePanel" class="pdp-time-panel">
+              <div class="pdp-time-panel-header">
+                <button
+                  class="pdp-time-panel-back"
+                  type="button"
+                  v-if="timePanelUnit === 'hour'"
+                  @click="showTimePanel = false"
+                >
+                  {{ lang.translations.hour || 'Hour' }}
+                </button>
+                <button
+                  class="pdp-time-panel-back"
+                  type="button"
+                  v-if="timePanelUnit === 'minute'"
+                  @click="showTimePanel = false"
+                >
+                  {{ lang.translations.minute || 'Minute' }}
+                </button>
+              </div>
+              <div class="pdp-time-panel-body">
+                <ul ref="timePanelList">
+                  <li
+                    v-for="(item, index) in timePanelValues"
+                    :key="index"
+                    :class="[
+                      { selected: item.selected },
+                      { disabled: item.disabled },
+                    ]"
+                    @click="selectTime(timePanelUnit, item.value)"
+                  >
+                    {{ item.label }}
+                  </li>
+                </ul>
+              </div>
+            </div>
             <div v-if="type.includes('date')" class="pdp-date">
               <div
                 v-for="(item, i) in columnCount"
@@ -234,11 +270,16 @@
                       @keyup.enter.prevent="stopChangeTime"
                     >
                       <slot name="up-arrow"><PDPArrow></PDPArrow></slot></button
-                    >{{
-                      selectedTimes[i]
-                        ? selectedTimes[i].hour('HH')
-                        : core.hour('HH')
-                    }}<button
+                    ><span
+                      class="pdp-time-display"
+                      @click="toggleTimeSelect('hour', i)"
+                    >
+                      {{
+                        selectedTimes[i]
+                          ? selectedTimes[i].hour('HH')
+                          : core.hour('HH')
+                      }} </span
+                    ><button
                       type="button"
                       @touchstart.prevent="startChangeTime(i, 'hour', 'sub')"
                       @mousedown.prevent="startChangeTime(i, 'hour', 'sub')"
@@ -266,11 +307,16 @@
                       @keyup.enter.prevent="stopChangeTime"
                     >
                       <slot name="up-arrow"><PDPArrow></PDPArrow></slot></button
-                    >{{
-                      selectedTimes[i]
-                        ? selectedTimes[i].minute('mm')
-                        : core.minute('mm')
-                    }}<button
+                    ><span
+                      class="pdp-time-display"
+                      @click="toggleTimeSelect('minute', i)"
+                    >
+                      {{
+                        selectedTimes[i]
+                          ? selectedTimes[i].minute('mm')
+                          : core.minute('mm')
+                      }} </span
+                    ><button
                       type="button"
                       @touchstart.prevent="startChangeTime(i, 'minute', 'sub')"
                       @mousedown.prevent="startChangeTime(i, 'minute', 'sub')"
@@ -637,6 +683,28 @@
         type: [Boolean, Object] as PropType<boolean | Shortcuts>,
         default: false,
       },
+
+      /**
+       * The step for the hour selection panel
+       * @type Number
+       * @default 1
+       * @since 3.0.0
+       */
+      hourStep: {
+        type: Number,
+        default: 1,
+      },
+
+      /**
+       * The step for the minute selection panel
+       * @type Number
+       * @default 5
+       * @since 3.0.0
+       */
+      minuteStep: {
+        type: Number,
+        default: 5,
+      },
     },
     emits: ['open', 'close', 'select', 'submit', 'clear', 'update:modelValue'],
     data() {
@@ -650,6 +718,9 @@
         showDatePicker: false,
         showYearSelect: false,
         showMonthSelect: false,
+        showTimePanel: false,
+        timePanelUnit: 'hour' as 'hour' | 'minute',
+        editingTimeIndex: 0,
         showTopOfInput: false,
         displayValue: [] as string[],
         inputName: 'firstInput' as Inputs,
@@ -719,7 +790,7 @@
             .find((bp) => this.documentWidth <= +bp);
           if (breakpoint) column = (this.column as Obj)[breakpoint] as number;
         }
-        if (this.type.includes('time')) {
+        if (this.type == 'time') {
           const scale = column / (this.mode == 'single' ? 1 : 2);
           (this.$refs.root as HTMLElement).style.setProperty(
             '--time-scale',
@@ -910,6 +981,47 @@
         }
         return shortcuts;
       },
+      hours(): object[] {
+        const hours = [];
+        const currentTime =
+          this.selectedTimes[this.editingTimeIndex] || this.core;
+        for (let h = 0; h < 24; h += this.hourStep) {
+          const tempDate = currentTime.clone();
+          tempDate.hour(h);
+          hours.push({
+            value: h,
+            label: tempDate.toString('HH'),
+            selected: currentTime.hour() === h,
+            disabled:
+              !this.checkDate(tempDate, 'time') || this.isInDisable(tempDate),
+          });
+        }
+        return hours;
+      },
+      minutes(): object[] {
+        const minutes = [];
+        const currentTime =
+          this.selectedTimes[this.editingTimeIndex] || this.core;
+        for (let m = 0; m < 60; m += this.minuteStep) {
+          const tempDate = currentTime.clone();
+          tempDate.minute(m);
+          minutes.push({
+            value: m,
+            label: tempDate.toString('mm'),
+            selected: currentTime.minute() === m,
+            disabled:
+              !this.checkDate(tempDate, 'time') || this.isInDisable(tempDate),
+          });
+        }
+        return minutes;
+      },
+      timePanelValues(): object[] {
+        if (this.timePanelUnit === 'hour') {
+          return this.hours;
+        } else {
+          return this.minutes;
+        }
+      },
     },
     watch: {
       show: {
@@ -923,6 +1035,7 @@
           else {
             if (!this.modal)
               document.removeEventListener('scroll', this.locate);
+            this.showTimePanel = false;
             this.$emit('close');
           }
         },
@@ -1613,6 +1726,84 @@
           }
         });
         if (this.selectedDates.length) this.submitDate();
+      },
+      toggleTimeSelect(unit: 'hour' | 'minute', index: number): void {
+        this.editingTimeIndex = index;
+        this.timePanelUnit = unit;
+        this.showTimePanel = true;
+        this.showYearSelect = false;
+        this.showMonthSelect = false;
+        this.$nextTick(() => {
+          const list = this.$refs.timePanelList as HTMLElement;
+          if (list) {
+            this.scrollToSelected(list);
+          }
+        });
+      },
+      scrollToSelected(container: HTMLElement): void {
+        if (!container) return;
+        const selectedEl = container.querySelector(
+          'li.selected',
+        ) as HTMLLIElement;
+        if (selectedEl) {
+          container.scrollTop =
+            selectedEl.offsetTop -
+            container.offsetHeight / 2 +
+            selectedEl.offsetHeight / 2;
+        }
+      },
+      selectTime(unit: 'hour' | 'minute', value: number): void {
+        const timeIndex = this.editingTimeIndex;
+        let time = this.selectedTimes[timeIndex];
+
+        if (!time) {
+          time = this.core.clone();
+          if (!this.checkDate(time, 'time')) {
+            time = this.toDate!.clone()
+              .subDay()
+              .time(this.core as PersianDate);
+          }
+          if (timeIndex === 1 && !this.selectedTimes.length) {
+            this.selectedTimes.push(time.clone());
+          }
+          this.selectedTimes[timeIndex] = time;
+        }
+
+        const newTime = time.clone()[unit](value);
+
+        if (this.checkDate(newTime, 'time') && !this.isInDisable(newTime)) {
+          if (
+            this.selectedTimes.length === 2 &&
+            ((timeIndex === 0 &&
+              this.selectedTimes[1] &&
+              newTime.isAfter(this.selectedTimes[1])) ||
+              (timeIndex === 1 &&
+                this.selectedTimes[0] &&
+                newTime.isBefore(this.selectedTimes[0])))
+          ) {
+            // invalid range
+          } else {
+            time[unit](value);
+
+            if (this.type === 'time') {
+              this.selectedDates[timeIndex] = time;
+            } else if (this.selectedDates[timeIndex]) {
+              this.selectedDates[timeIndex].time(time as PersianDate);
+            }
+
+            this.$emit('select', time);
+
+            if (
+              this.autoSubmit &&
+              !this.selectedTimes.some((sTime) =>
+                this.isInDisable(sTime as PersianDate),
+              )
+            ) {
+              this.submitDate(false);
+            }
+          }
+        }
+        this.showTimePanel = false;
       },
     },
   });

--- a/src/components/assets/sass/app.scss
+++ b/src/components/assets/sass/app.scss
@@ -257,6 +257,25 @@
     }
   }
 
+  &.pdp--time-panel-open {
+    .pdp-auto {
+      margin: 0;
+    }
+
+    .pdp-main .pdp-date,
+    .pdp-main .pdp-time.inline {
+      visibility: hidden;
+    }
+
+    .pdp-header {
+      display: none;
+    }
+
+    .pdp-main {
+      min-height: 19rem;
+    }
+  }
+
   * {
     box-sizing: border-box;
   }
@@ -760,7 +779,7 @@
       justify-content: space-between;
       border-top: 1px solid variable.$border-color;
       border-top: 1px solid var(--border-color);
-      padding: 0.3rem;
+      padding: 0.5rem 0.3rem;
 
       .pdp-today,
       .pdp-submit {
@@ -785,6 +804,7 @@
 
       > div {
         display: flex;
+        align-items: center;
       }
     }
 
@@ -821,6 +841,105 @@
           color: variable.$background;
           color: var(--background);
         }
+      }
+    }
+
+    .pdp-time-panel {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--background);
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      animation: start 0.4s;
+
+      &-header {
+        position: relative; // For absolute positioning of back button
+        display: flex;
+        align-items: center;
+        justify-content: center; // Center title
+        text-align: center;
+        padding: 0.75rem;
+        border-bottom: 1px solid var(--border-color);
+        color: var(--primary-color);
+        font-weight: bold;
+
+        & > div {
+          display: flex;
+          flex-grow: 1;
+          justify-content: space-around;
+        }
+
+        button {
+          font-size: 1.2rem;
+          background: inherit;
+          color: var(--primary-color);
+          border: 0;
+          cursor: pointer;
+
+          &:focus {
+            outline: 0;
+          }
+        }
+      }
+
+      &-body {
+        flex: 1;
+        overflow: hidden;
+
+        ul {
+          list-style: none;
+          padding: 1rem;
+          margin: 0;
+          height: 100%;
+          overflow-y: auto;
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 0.5rem;
+          @include scrollbar();
+
+          li {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 3rem;
+            cursor: pointer;
+            border-radius: 8px;
+            transition: background-color 0.15s ease-in-out;
+            font-size: 0.9rem;
+
+            &:hover:not(.disabled) {
+              background-color: #f0f0f0;
+            }
+
+            &.selected {
+              background-color: var(--primary-color) !important;
+              color: white !important;
+              font-weight: bold;
+            }
+
+            &.disabled {
+              cursor: default !important;
+              opacity: var(--disabled-opacity);
+              background-color: transparent !important;
+              color: inherit;
+            }
+          }
+        }
+      }
+    }
+
+    .pdp-main .pdp-time .pdp-moment > div div .pdp-time-display {
+      cursor: pointer;
+      padding: 0 0.2rem;
+      border-radius: var(--radius);
+      transition: background-color 0.15s ease-in-out;
+
+      &:hover {
+        background-color: var(--in-range-background);
       }
     }
   }

--- a/src/components/utils/modules/core.ts
+++ b/src/components/utils/modules/core.ts
@@ -31,6 +31,8 @@ export const Core = {
         nextMonth: 'ماه بعد',
         now: 'هم اکنون',
         submit: 'تایید',
+        hour: 'ساعت',
+        minute: 'دقیقه',
         /* use in shourcuts */
         // date-single
         yesterday: 'دیروز',
@@ -84,6 +86,8 @@ export const Core = {
         nextMonth: 'Next Month',
         now: 'Now',
         submit: 'Submit',
+        hour: 'Hour',
+        minute: 'Minute',
         /* use in shourcuts */
         // date-single
         yesterday: 'Yesterday',

--- a/src/components/utils/modules/types.ts
+++ b/src/components/utils/modules/types.ts
@@ -85,6 +85,8 @@ export type Langs = {
       nextMonth: string;
       now: string;
       submit: string;
+      hour: string;
+      minute: string;
       /* use in shourcuts */
       // date-single
       yesterday: string;


### PR DESCRIPTION
quick time selection panel: clicking directly on the displayed hour or minute value in the time input section now opens a dedicated, scrollable panel. users can select their desired time instantly from this panel.

enhanced usability: the new panels streamline the time-setting process, especially when setting times far from the current value (jumping from 05 to 50 minutes).

two new optional props have been added to allow developers to control the interval of the values displayed in the selection panels

hourStep: 1 | defines the interval between displayed hour options in the selection panel.

minuteStep: 5	| defines the interval between displayed minute options in the selection panel. the default 5 shows minutes in 5 minute increments (00, 05, 10, 15, ..., 55).

<img width="818" height="295" alt="image" src="https://github.com/user-attachments/assets/b2009a53-a98b-43b0-94b6-e194dce63c17" />
<img width="815" height="362" alt="image" src="https://github.com/user-attachments/assets/776ef1af-59ab-45c3-8e82-7e0252768b16" />
<img width="819" height="362" alt="image" src="https://github.com/user-attachments/assets/bf336186-774a-4653-836d-f5037329b6fa" />
